### PR TITLE
Restyle PT25w class2 page to match class1 aesthetic

### DIFF
--- a/PT25w/class2/class2.html
+++ b/PT25w/class2/class2.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>確率論と統計学I　レジュメ2</title>
-    <!-- MathJax CDN -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({
@@ -18,414 +17,571 @@
         });
     </script>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Cabin:wght@500&family=Noto+Sans+JP:wght@400;500;700&display=swap');
+
+        :root {
+            --background: radial-gradient(120% 120% at 20% 20%, #1e3a8a 0%, #0f172a 55%, #020617 100%);
+            --card-bg: rgba(255, 255, 255, 0.88);
+            --card-border: rgba(255, 255, 255, 0.25);
+            --accent: #4c6ef5;
+            --accent-soft: rgba(76, 110, 245, 0.14);
+            --accent-strong: #2c3791;
+            --text-primary: #0f172a;
+            --text-secondary: #475569;
+            --highlight: #facc15;
+            --shadow: 0 18px 45px -25px rgba(15, 23, 42, 0.75);
+        }
+
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
         body {
-            font-family: 'Hiragino Sans', 'Meiryo', sans-serif;
-            line-height: 1.6;
+            font-family: 'Noto Sans JP', 'Hiragino Sans', 'Meiryo', sans-serif;
+            line-height: 1.7;
             margin: 0;
-            padding: 0;
-            color: #333;
-            background-color: #f5f5f5;
-        }
-        .container {
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #fff;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-        }
-        h1 {
-            color: #1a237e;
-            text-align: center;
-            margin-bottom: 30px;
-            border-bottom: 2px solid #1a237e;
-            padding-bottom: 10px;
-            font-size: 2em;
-        }
-        h2 {
-            color: #303f9f;
-            margin-top: 30px;
-            border-left: 5px solid #303f9f;
-            padding-left: 10px;
-        }
-        h3 {
-            color: #3949ab;
-        }
-        .example {
-            background-color: #e8eaf6;
-            padding: 15px;
-            border-radius: 5px;
-            margin: 20px 0;
-        }
-        .definition {
-            background-color: #fff8e1;
-            padding: 15px;
-            border-radius: 5px;
-            margin: 20px 0;
-            border-left: 3px solid #ffc107;
-        }
-        .formula {
-            font-style: italic;
-            background-color: #f1f8e9;
-            padding: 10px;
-            border-radius: 5px;
-            text-align: center;
-            margin: 15px 0;
-        }
-        .history {
-            background-color: #e0f2f1;
-            padding: 15px;
-            border-radius: 5px;
-            margin: 20px 0;
-        }
-        .coin-toss {
-            display: flex;
-            justify-content: center;
-            margin: 20px 0;
-        }
-        .coin {
-            width: 100px;
-            height: 100px;
-            background-color: #ffd700;
-            border-radius: 50%;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin: 0 20px;
-            font-weight: bold;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-        }
-        .figure {
-            margin: 30px auto;
-            text-align: center;
-        }
-        .figure img {
-            max-width: 100%;
-            border-radius: 5px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        .figure-caption {
-            font-style: italic;
-            color: #666;
-            margin-top: 10px;
-        }
-        .probability-map {
-            width: 100%;
-            height: 400px;
-            background-color: #f9f9f9;
-            border-radius: 8px;
+            min-height: 100vh;
+            padding: 60px 24px;
+            color: var(--text-primary);
+            background: var(--background);
             position: relative;
-            margin: 30px 0;
-            overflow: hidden;
-        }
-        .prob-node {
-            position: absolute;
-            width: 120px;
-            height: 50px;
-            background-color: #3f51b5;
-            color: white;
-            border-radius: 25px;
             display: flex;
             justify-content: center;
-            align-items: center;
-            font-weight: bold;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+            align-items: flex-start;
         }
-        .prob-line {
-            position: absolute;
-            background-color: #ccc;
+
+        body::before {
+            content: "";
+            position: fixed;
+            inset: 0;
+            background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0, rgba(255, 255, 255, 0.04) 12px, transparent 12px, transparent 24px);
+            pointer-events: none;
             z-index: 0;
         }
-        .sample-space {
-            display: flex;
-            justify-content: space-around;
-            margin: 30px 0;
-            text-align: center;
-        }
-        .outcome {
-            padding: 15px;
-            background-color: #e3f2fd;
-            border-radius: 5px;
-            margin: 0 5px;
-            flex: 1;
-        }
-        .venn-diagram {
+
+        main {
+            width: min(960px, 100%);
+            background: var(--card-bg);
+            backdrop-filter: blur(18px);
+            border: 1px solid var(--card-border);
+            border-radius: 28px;
+            padding: 56px 64px;
             position: relative;
-            height: 300px;
-            margin: 30px 0;
+            z-index: 1;
+            box-shadow: var(--shadow);
         }
-        .venn-circle {
-            position: absolute;
-            border-radius: 50%;
-            opacity: 0.6;
-        }
-        .theorem {
-            background-color: #e8f5e9;
-            padding: 15px;
-            border-radius: 5px;
-            margin: 20px 0;
-            border-left: 3px solid #4caf50;
-        }
-        ul.itemize {
-            list-style-type: disc;
-            padding-left: 20px;
-        }
-        .align {
-            display: block;
+
+        header.hero {
             text-align: center;
-            margin: 15px 0;
+            margin-bottom: 52px;
+            display: grid;
+            gap: 18px;
+        }
+
+        .hero-label {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 6px 16px;
+            border-radius: 999px;
+            font-size: 14px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--accent-strong);
+            background: var(--accent-soft);
+            font-family: 'Cabin', sans-serif;
+        }
+
+        h1 {
+            font-size: clamp(32px, 4vw, 44px);
+            margin: 0;
+            color: var(--accent-strong);
+            letter-spacing: 0.05em;
+        }
+
+        .hero p {
+            margin: 0 auto;
+            max-width: 640px;
+            color: var(--text-secondary);
+            font-size: 17px;
+        }
+
+        section.outline-section {
+            background: rgba(255, 255, 255, 0.78);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            padding: 32px 36px;
+            border-radius: 22px;
+            margin-bottom: 32px;
+            box-shadow: 0 24px 40px -32px rgba(15, 23, 42, 0.35);
+        }
+
+        section.outline-section:last-of-type {
+            margin-bottom: 48px;
+        }
+
+        section.outline-section h2 {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            font-size: 24px;
+            margin: 0 0 24px;
+            color: var(--accent-strong);
+        }
+
+        section.outline-section h2::before {
+            content: "";
+            width: 42px;
+            height: 4px;
+            border-radius: 999px;
+            background: linear-gradient(90deg, var(--accent) 0%, rgba(76, 110, 245, 0.2) 100%);
+        }
+
+        section.outline-section h3 {
+            margin: 28px 0 14px;
+            font-size: 19px;
+            color: var(--accent-strong);
+        }
+
+        section.outline-section p {
+            margin: 0 0 16px;
+            color: var(--text-secondary);
+        }
+
+        ul.styled-list {
+            margin: 0 0 18px;
+            padding-left: 22px;
+            color: var(--text-secondary);
+        }
+
+        ul.styled-list li {
+            margin-bottom: 8px;
+        }
+
+        .math-card {
+            background: rgba(226, 232, 240, 0.5);
+            border: 1px solid rgba(148, 163, 184, 0.3);
+            border-radius: 18px;
+            padding: 18px 22px;
+            margin: 18px 0;
+            text-align: center;
+            font-size: 17px;
+        }
+
+        .callout {
+            background: rgba(255, 255, 255, 0.86);
+            border-radius: 18px;
+            padding: 22px 24px;
+            border: 1px solid rgba(148, 163, 184, 0.28);
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+            margin: 24px 0;
+        }
+
+        .callout h3 {
+            margin-top: 0;
+            margin-bottom: 12px;
+            font-size: 18px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .callout h3::before {
+            content: "";
+            width: 30px;
+            height: 3px;
+            border-radius: 999px;
+            background: currentColor;
+            opacity: 0.35;
+        }
+
+        .callout.definition {
+            border-left: 4px solid #f59f00;
+        }
+
+        .callout.definition h3 {
+            color: #b97309;
+        }
+
+        .callout.example {
+            border-left: 4px solid var(--accent);
+        }
+
+        .callout.example h3 {
+            color: var(--accent-strong);
+        }
+
+        .callout.theorem {
+            border-left: 4px solid #2f9e44;
+            background: rgba(240, 253, 244, 0.92);
+        }
+
+        .callout.theorem h3 {
+            color: #2f9e44;
+        }
+
+        .visual-grid {
+            display: grid;
+            gap: 26px;
+        }
+
+        .sample-space {
+            display: grid;
+            gap: 18px;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        }
+
+        .sample-space .outcome {
+            background: rgba(236, 243, 255, 0.9);
+            border-radius: 18px;
+            padding: 18px;
+            text-align: center;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+        }
+
+        .coin {
+            width: 90px;
+            height: 90px;
+            background: radial-gradient(circle at 30% 30%, #ffe066, #f59f00);
+            border-radius: 50%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin: 0 auto 14px;
+            font-weight: 700;
+            color: #2c1b00;
+            letter-spacing: 0.08em;
+            box-shadow: 0 10px 25px -12px rgba(245, 159, 0, 0.6);
+        }
+
+        .probability-map {
+            background: rgba(226, 232, 240, 0.45);
+            border-radius: 22px;
+            padding: 24px;
+            border: 1px solid rgba(148, 163, 184, 0.3);
+            overflow: hidden;
+        }
+
+        .probability-map svg {
+            width: 100%;
+            height: auto;
+        }
+
+        .figure {
+            margin: 24px 0 0;
+            text-align: center;
+        }
+
+        .figure svg {
+            max-width: 100%;
+        }
+
+        .nav-links {
+            display: flex;
+            justify-content: center;
+            gap: 12px;
+            margin-top: 16px;
+        }
+
+        .nav-links a {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 10px 22px;
+            border-radius: 999px;
+            background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+            color: white;
+            text-decoration: none;
+            font-weight: 500;
+            letter-spacing: 0.04em;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .nav-links a:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 30px -18px rgba(76, 110, 245, 0.8);
+        }
+
+        footer {
+            text-align: center;
+            color: rgba(71, 85, 105, 0.8);
+            font-size: 14px;
+        }
+
+        @media (max-width: 720px) {
+            body {
+                padding: 32px 16px;
+            }
+
+            main {
+                padding: 40px 26px;
+            }
+
+            section.outline-section {
+                padding: 24px;
+            }
+
+            .probability-map {
+                padding: 18px;
+            }
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        <h1>確率論と統計学I　レジュメ2</h1>
+    <main>
+        <header class="hero">
+            <span class="hero-label">Lecture 2</span>
+            <h1>確率論と統計学I　レジュメ2</h1>
+            <p>有限な確率空間の構成と基礎的な確率変数の扱いを、コイントスの具体例を通して整理します。</p>
+        </header>
 
-        <h2>1. コイントス</h2>
-        <p>コインを2回投げる:</p>
-        <ul class="itemize">
-            <li>(全事象) $\Omega=\{(\text{表,表}),(\text{表,裏}),(\text{裏,表}),(\text{裏,裏})\}$</li>
-            <li>(確率測度) $\mathbb{P}(\text{表,表})=\mathbb{P}(\text{表,裏})=\mathbb{P}(\text{裏,表})=\mathbb{P}(\text{裏,裏})=1/4$</li>
-        </ul>
-
-                    <p>$X$を2回投げたコインの表の数とする。この時次のように$X$は$\Omega$から$\mathbb{R}$への写像と見ることができる:</p>
-        <div class="formula">
-            $X(\text{表,表})=2, X(\text{表,裏})=1, X(\text{裏,表})=1, X(\text{裏,裏})=0$
-        </div>
-
-        <div class="definition">
-            <h3>定義</h3>
-            <p>$X$の平均を次で定義:</p>
-            <div class="formula">
-                $$\mathbb{E}[X] \equiv \sum_{\omega\in \Omega}X(\omega)\mathbb{P}(\omega)=2\cdot \frac{1}{4}+1\cdot \frac{2}{4}+0\cdot\frac{1}{4}=1$$
-            </div>
-        </div>
-        <h3>コイントスの視覚化</h3>
-        <div class="sample-space">
-            <div class="outcome">
-                <div class="coin">表表</div>
-                <p>$X = 2$</p>
-                <p>$\mathbb{P} = \frac{1}{4}$</p>
-            </div>
-            <div class="outcome">
-                <div class="coin">表裏</div>
-                <p>$X = 1$</p>
-                <p>$\mathbb{P} = \frac{1}{4}$</p>
-            </div>
-            <div class="outcome">
-                <div class="coin">裏表</div>
-                <p>$X = 1$</p>
-                <p>$\mathbb{P} = \frac{1}{4}$</p>
-            </div>
-            <div class="outcome">
-                <div class="coin">裏裏</div>
-                <p>$X = 0$</p>
-                <p>$\mathbb{P} = \frac{1}{4}$</p>
-            </div>
-        </div>
-        
-        <div class="probability-map">
-            <svg viewBox="0 0 400 300" width="100%" height="100%">
-                <!-- 確率空間の視覚化 -->
-                <rect x="50" y="50" width="300" height="200" fill="#f0f8ff" stroke="#3949ab" stroke-width="2" rx="10" />
-                <text x="200" y="30" text-anchor="middle" font-size="16">確率空間 $(\Omega, \mathbb{P})$</text>
-                
-                <!-- サンプル点 -->
-                <circle cx="100" cy="100" r="20" fill="#3f51b5" />
-                <text x="100" y="105" text-anchor="middle" fill="white">(表,表)</text>
-                
-                <circle cx="300" cy="100" r="20" fill="#3f51b5" />
-                <text x="300" y="105" text-anchor="middle" fill="white">(表,裏)</text>
-                
-                <circle cx="100" cy="200" r="20" fill="#3f51b5" />
-                <text x="100" y="205" text-anchor="middle" fill="white">(裏,表)</text>
-                
-                <circle cx="300" cy="200" r="20" fill="#3f51b5" />
-                <text x="300" y="205" text-anchor="middle" fill="white">(裏,裏)</text>
-                
-                <!-- 確率変数Xのマッピング -->
-                <path d="M 350 125 L 380 125 L 380 75 L 410 125 L 380 175 L 380 125" fill="none" stroke="#303f9f" stroke-width="2" />
-                <text x="420" y="125" text-anchor="start">$X$</text>
-                
-                <!-- 実数線 -->
-                <line x1="450" y1="50" x2="450" y2="250" stroke="#1a237e" stroke-width="2" />
-                <circle cx="450" cy="75" r="5" fill="#1a237e" />
-                <text x="465" y="80" text-anchor="start">$2$</text>
-                
-                <circle cx="450" cy="150" r="5" fill="#1a237e" />
-                <text x="465" y="155" text-anchor="start">$1$</text>
-                
-                <circle cx="450" cy="225" r="5" fill="#1a237e" />
-                <text x="465" y="230" text-anchor="start">$0$</text>
-            </svg>
-        </div>
-        
-        <!-- 分布関数の視覚化 -->
-        <h3>分布関数の例</h3>
-        <div class="figure">
-            <svg viewBox="0 0 400 250">
-                <!-- 座標軸 -->
-                <line x1="50" y1="200" x2="350" y2="200" stroke="#333" stroke-width="2" /> <!-- x軸 -->
-                <line x1="50" y1="50" x2="50" y2="200" stroke="#333" stroke-width="2" /> <!-- y軸 -->
-                
-                <!-- 目盛り -->
-                <line x1="50" y1="200" x2="50" y2="205" stroke="#333" stroke-width="2" />
-                <text x="50" y="220" text-anchor="middle">0</text>
-                
-                <line x1="150" y1="200" x2="150" y2="205" stroke="#333" stroke-width="2" />
-                <text x="150" y="220" text-anchor="middle">1</text>
-                
-                <line x1="250" y1="200" x2="250" y2="205" stroke="#333" stroke-width="2" />
-                <text x="250" y="220" text-anchor="middle">2</text>
-                
-                <line x1="350" y1="200" x2="350" y2="205" stroke="#333" stroke-width="2" />
-                <text x="350" y="220" text-anchor="middle">∞</text>
-                
-                <line x1="45" y1="50" x2="50" y2="50" stroke="#333" stroke-width="2" />
-                <text x="40" y="55" text-anchor="end">1</text>
-                
-                <line x1="45" y1="125" x2="50" y2="125" stroke="#333" stroke-width="2" />
-                <text x="40" y="130" text-anchor="end">1/2</text>
-                
-                <line x1="45" y1="200" x2="50" y2="200" stroke="#333" stroke-width="2" />
-                <text x="40" y="205" text-anchor="end">0</text>
-                
-                <!-- 軸ラベル -->
-                <text x="200" y="240" text-anchor="middle">$x$</text>
-                <text x="30" y="125" text-anchor="middle" transform="rotate(-90, 30, 125)">$F_X(x)$</text>
-                
-                <!-- 分布関数 (コイントス2回の例) -->
-                <!-- 0から1までy=0 -->
-                <line x1="50" y1="200" x2="150" y2="200" stroke="#3f51b5" stroke-width="3" />
-                <circle cx="50" cy="200" r="4" fill="#3f51b5" />
-                <circle cx="150" cy="200" r="4" fill="white" stroke="#3f51b5" stroke-width="2" />
-                
-                <!-- 1から2までy=1/2 -->
-                <line x1="150" y1="125" x2="250" y2="125" stroke="#3f51b5" stroke-width="3" />
-                <circle cx="150" cy="125" r="4" fill="#3f51b5" />
-                <circle cx="250" cy="125" r="4" fill="white" stroke="#3f51b5" stroke-width="2" />
-                
-                <!-- 2から∞までy=1 -->
-                <line x1="250" y1="50" x2="350" y2="50" stroke="#3f51b5" stroke-width="3" />
-                <circle cx="250" cy="50" r="4" fill="#3f51b5" />
-                <circle cx="350" cy="50" r="4" fill="#3f51b5" />
-                
-                <!-- 説明テキスト -->
-                <text x="280" y="80" text-anchor="start" font-size="10">分布関数:</text>
-                <text x="280" y="100" text-anchor="start" font-size="10">$F_X(x) = \mathbb{P}(X \leq x)$</text>
-                <text x="280" y="120" text-anchor="start" font-size="10">$F_X(x) = 0, 0 \leq x < 1$</text>
-                <text x="280" y="140" text-anchor="start" font-size="10">$F_X(x) = 1/2, 1 \leq x < 2$</text>
-                <text x="280" y="160" text-anchor="start" font-size="10">$F_X(x) = 1, x \geq 2$</text>
-            </svg>
-        </div>
-        <h2>2. 確率空間と確率変数 (抽象的な定義)</h2>
-        <div class="definition">
-            <h3>定義</h3>
-            <p>$\Omega$ (<i>全事象</i>)を有限(または可算)集合とする。それぞれの元$a \in \Omega$に対し、出現確率を表す$p_a$が対応しており次を満たすとする:</p>
-            <div class="formula">
-                $$\begin{cases}
-                0 \leq p_a \leq 1,\\
-                \sum_{a \in \Omega}p_a = 1.
-                \end{cases}$$
-            </div>
-            <p>さらに集合$A \subset \Omega$に対し、$A$が起こる確率を$\mathbb{P}(A) = \sum_{a \in A}p_a$で定義する。組$(\Omega, \mathbb{P})$を<strong>確率空間</strong>と呼ぶ。さらに$\Omega$から$\mathbb{R}$への写像を確率変数と呼ぶ。</p>
-        </div>
-
-        <div class="definition">
-            <h3>定義</h3>
-            <p>集合$A \subset \mathbb{R}$について、$\mathbb{P}(X \in A) \equiv \mathbb{P}(\{\omega \in \Omega | X(\omega) \in A\})$で定義する。対応関係$A \longrightarrow \mathbb{P}(X \in A)$を$X$の分布と呼ぶ。</p>
-            <p>$X$の平均 (期待値とも呼ぶ) を次で定義:</p>
-            <div class="formula">
-                $$\mathbb{E}[X] \equiv \sum_{\omega \in \Omega}X(\omega)\mathbb{P}(\omega)$$
-            </div>
-        </div>
-        
-        <div class="definition">
-            <h3>確率分布と分布関数</h3>
-            <p>確率変数$X$の確率分布は次のように表される:</p>
-            <div class="formula">
-                $$\mathbb{P}(X=x) = \sum_{\omega\in \Omega: X(\omega)=x} \mathbb{P}(\omega) = \sum_{\omega \in \Omega} \mathbb{P}(\omega)1_{X(\omega)=x}$$
-            </div>
-            <p>ここで$1_{X(\omega)=x}$は指示関数で、$X(\omega)=x$のとき$1$、そうでないとき$0$の値をとる。</p>
-            <p>また、$X$の分布関数$F_X$を次で定義する:</p>
-            <div class="formula">
-                $$F_X(x) = \mathbb{P}(X \leq x)$$
-            </div>
-        </div>
-        
-        <div class="example">
-            <h3>記法についての注意</h3>
-            <p>確率変数$X$に関する条件を含む事象について、次のような略記法を用いる:</p>
-            <div class="formula">
-                $$\mathbb{P}(X \in A) = \mathbb{P}(\{\omega \in \Omega : X(\omega) \in A\})$$
-            </div>
-            <p>同様に:</p>
-            <div class="formula">
-                $$\mathbb{P}(X \leq x) = \mathbb{P}(\{\omega \in \Omega : X(\omega) \leq x\})$$
-                $$\mathbb{P}(X = x) = \mathbb{P}(\{\omega \in \Omega : X(\omega) = x\})$$
-            </div>
-            <p>これにより記法が簡潔になり、確率変数に関する事象を直接扱うことができる。</p>
-        </div>
-
-        <div class="example">
-            <h3>例題</h3>
-            <p>次の設定の下で確率空間を定義し、期待値を求めよ。</p>
-            <ul class="itemize">
-                <li>サイコロを1回振り，出た目の期待値</li>
-                <li>コインを3回投げたときの，表の出た数</li>
+        <section class="outline-section">
+            <h2>1. コイントス</h2>
+            <p>コインを2回投げる状況を考えると、結果の組み合わせ全体は次の集合で表されます。</p>
+            <ul class="styled-list">
+                <li>(全事象) $\Omega=\{(\text{表,表}),(\text{表,裏}),(\text{裏,表}),(\text{裏,裏})\}$</li>
+                <li>(確率測度) $\mathbb{P}(\text{表,表})=\mathbb{P}(\text{表,裏})=\mathbb{P}(\text{裏,表})=\mathbb{P}(\text{裏,裏})=1/4$</li>
             </ul>
-            
-            <p>解答例：</p>
-            <p>1. サイコロの場合：</p>
-            <ul>
-                <li>$\Omega = \{1,2,3,4,5,6\}$</li>
-                <li>$\mathbb{P}(1) = \mathbb{P}(2) = \mathbb{P}(3) = \mathbb{P}(4) = \mathbb{P}(5) = \mathbb{P}(6) = \frac{1}{6}$</li>
-                <li>$X(\omega) = \omega$ （出目をそのまま値とする）</li>
-                <li>$\mathbb{E}[X] = \sum_{\omega \in \Omega} X(\omega)\mathbb{P}(\omega) = 1 \cdot \frac{1}{6} + 2 \cdot \frac{1}{6} + 3 \cdot \frac{1}{6} + 4 \cdot \frac{1}{6} + 5 \cdot \frac{1}{6} + 6 \cdot \frac{1}{6} = \frac{21}{6} = 3.5$</li>
-            </ul>
-            
-            <p>2. コインを3回投げる場合：</p>
-            <ul>
-                <li>全事象：$\Omega = \{(x_1,x_2,x_3) \mid x_i \in \{\text{表},\text{裏}\}, i=1,2,3\}$</li>
-                <li>具体的には：
-                    $$\Omega = \left\{ \begin{array}{cccc}
-                    (表,表,表), & (表,表,裏), & (表,裏,表), & (表,裏,裏), \\
-                    (裏,表,表), & (裏,表,裏), & (裏,裏,表), & (裏,裏,裏)
-                    \end{array} \right\}$$
-                </li>
-                <li>$|\Omega| = 2^3 = 8$より、各要素の確率は$\mathbb{P}(\omega) = \frac{1}{8}$</li>
-                <li>確率変数$X$：表の出た数</li>
-                <li>期待値の計算：
-                    $$\begin{align*}
-                    \mathbb{E}[X] &= 3 \cdot \mathbb{P}(X=3) + 2 \cdot \mathbb{P}(X=2) + 1 \cdot \mathbb{P}(X=1) + 0 \cdot \mathbb{P}(X=0)\\
-                    &= 3 \cdot \frac{1}{8} + 2 \cdot \frac{3}{8} + 1 \cdot \frac{3}{8} + 0 \cdot \frac{1}{8}\\
-                    &= \frac{3+6+3+0}{8} = \frac{12}{8} = 1.5
-                    \end{align*}$$
-                </li>
-            </ul>
-        </div>
-
-        <div class="theorem">
-            <h3>定理</h3>
-            <p>次が成立:</p>
-            <div class="formula">
-                $$\begin{align}
-                \mathbb{P}(A \cup B) &\leq \mathbb{P}(A) + \mathbb{P}(B)\\
-                \mathbb{P}(A^c) &= 1 - \mathbb{P}(A)\\
-                \mathbb{E}[X] &= \sum_{x \in I_X} x \cdot \mathbb{P}(X = x)
-                \end{align}$$
+            <p>$X$を2回投げたコインの表の数とすると、$X$は$\Omega$から$\mathbb{R}$への写像として表現できます。</p>
+            <div class="math-card">
+                $X(\text{表,表})=2,\; X(\text{表,裏})=1,\; X(\text{裏,表})=1,\; X(\text{裏,裏})=0$
             </div>
-            <p>ここで$I_X \equiv \{X(\omega) | \omega \in \Omega\}$は$X$の値域。</p>
-        </div>
 
-        <div class="navigation" style="display: flex; justify-content: center; margin: 20px 0; padding: 15px 0; border-top: 1px solid #eee;">
-            <a href="class1.html" style="padding: 10px 20px; background-color: #1a237e; color: white; text-decoration: none; border-radius: 5px; margin-right: 10px;">← 前のレッスン</a>
-            <a href="../index.html" style="padding: 10px 20px; background-color: #1a237e; color: white; text-decoration: none; border-radius: 5px; margin-right: 10px;">ホーム</a>
-            <a href="class3.html" style="padding: 10px 20px; background-color: #1a237e; color: white; text-decoration: none; border-radius: 5px;">次のレッスン →</a>
+            <div class="callout definition">
+                <h3>平均 (期待値) の定義</h3>
+                <p>$X$の平均を次で定義します。</p>
+                <div class="math-card">
+                    $$\mathbb{E}[X] \equiv \sum_{\omega\in \Omega}X(\omega)\mathbb{P}(\omega)=2\cdot \frac{1}{4}+1\cdot \frac{2}{4}+0\cdot\frac{1}{4}=1$$
+                </div>
+            </div>
+
+            <h3>コイントスの視覚化</h3>
+            <div class="visual-grid">
+                <div class="sample-space">
+                    <div class="outcome">
+                        <div class="coin">表表</div>
+                        <p>$X = 2$</p>
+                        <p>$\mathbb{P} = \frac{1}{4}$</p>
+                    </div>
+                    <div class="outcome">
+                        <div class="coin">表裏</div>
+                        <p>$X = 1$</p>
+                        <p>$\mathbb{P} = \frac{1}{4}$</p>
+                    </div>
+                    <div class="outcome">
+                        <div class="coin">裏表</div>
+                        <p>$X = 1$</p>
+                        <p>$\mathbb{P} = \frac{1}{4}$</p>
+                    </div>
+                    <div class="outcome">
+                        <div class="coin">裏裏</div>
+                        <p>$X = 0$</p>
+                        <p>$\mathbb{P} = \frac{1}{4}$</p>
+                    </div>
+                </div>
+
+                <div class="probability-map">
+                    <svg viewBox="0 0 480 300">
+                        <rect x="50" y="50" width="300" height="200" fill="#f0f8ff" stroke="#3949ab" stroke-width="2" rx="10" />
+                        <text x="200" y="30" text-anchor="middle" font-size="16">確率空間 $(\Omega, \mathbb{P})$</text>
+
+                        <circle cx="100" cy="100" r="20" fill="#3f51b5" />
+                        <text x="100" y="105" text-anchor="middle" fill="white">(表,表)</text>
+
+                        <circle cx="300" cy="100" r="20" fill="#3f51b5" />
+                        <text x="300" y="105" text-anchor="middle" fill="white">(表,裏)</text>
+
+                        <circle cx="100" cy="200" r="20" fill="#3f51b5" />
+                        <text x="100" y="205" text-anchor="middle" fill="white">(裏,表)</text>
+
+                        <circle cx="300" cy="200" r="20" fill="#3f51b5" />
+                        <text x="300" y="205" text-anchor="middle" fill="white">(裏,裏)</text>
+
+                        <path d="M 350 125 L 380 125 L 380 75 L 410 125 L 380 175 L 380 125" fill="none" stroke="#303f9f" stroke-width="2" />
+                        <text x="420" y="125" text-anchor="start">$X$</text>
+
+                        <line x1="450" y1="50" x2="450" y2="250" stroke="#1a237e" stroke-width="2" />
+                        <circle cx="450" cy="75" r="5" fill="#1a237e" />
+                        <text x="465" y="80" text-anchor="start">$2$</text>
+
+                        <circle cx="450" cy="150" r="5" fill="#1a237e" />
+                        <text x="465" y="155" text-anchor="start">$1$</text>
+
+                        <circle cx="450" cy="225" r="5" fill="#1a237e" />
+                        <text x="465" y="230" text-anchor="start">$0$</text>
+                    </svg>
+                </div>
+
+                <div class="figure">
+                    <svg viewBox="0 0 400 250">
+                        <line x1="50" y1="200" x2="350" y2="200" stroke="#333" stroke-width="2" />
+                        <line x1="50" y1="50" x2="50" y2="200" stroke="#333" stroke-width="2" />
+
+                        <line x1="50" y1="200" x2="50" y2="205" stroke="#333" stroke-width="2" />
+                        <text x="50" y="220" text-anchor="middle">0</text>
+
+                        <line x1="150" y1="200" x2="150" y2="205" stroke="#333" stroke-width="2" />
+                        <text x="150" y="220" text-anchor="middle">1</text>
+
+                        <line x1="250" y1="200" x2="250" y2="205" stroke="#333" stroke-width="2" />
+                        <text x="250" y="220" text-anchor="middle">2</text>
+
+                        <line x1="350" y1="200" x2="350" y2="205" stroke="#333" stroke-width="2" />
+                        <text x="350" y="220" text-anchor="middle">∞</text>
+
+                        <line x1="45" y1="50" x2="50" y2="50" stroke="#333" stroke-width="2" />
+                        <text x="40" y="55" text-anchor="end">1</text>
+
+                        <line x1="45" y1="125" x2="50" y2="125" stroke="#333" stroke-width="2" />
+                        <text x="40" y="130" text-anchor="end">1/2</text>
+
+                        <line x1="45" y1="200" x2="50" y2="200" stroke="#333" stroke-width="2" />
+                        <text x="40" y="205" text-anchor="end">0</text>
+
+                        <text x="200" y="240" text-anchor="middle">$x$</text>
+                        <text x="30" y="125" text-anchor="middle" transform="rotate(-90, 30, 125)">$F_X(x)$</text>
+
+                        <line x1="50" y1="200" x2="150" y2="200" stroke="#3f51b5" stroke-width="3" />
+                        <circle cx="50" cy="200" r="4" fill="#3f51b5" />
+                        <circle cx="150" cy="200" r="4" fill="white" stroke="#3f51b5" stroke-width="2" />
+
+                        <line x1="150" y1="125" x2="250" y2="125" stroke="#3f51b5" stroke-width="3" />
+                        <circle cx="150" cy="125" r="4" fill="#3f51b5" />
+                        <circle cx="250" cy="125" r="4" fill="white" stroke="#3f51b5" stroke-width="2" />
+
+                        <line x1="250" y1="50" x2="350" y2="50" stroke="#3f51b5" stroke-width="3" />
+                        <circle cx="250" cy="50" r="4" fill="#3f51b5" />
+                        <circle cx="350" cy="50" r="4" fill="#3f51b5" />
+
+                        <text x="280" y="80" text-anchor="start" font-size="10">分布関数:</text>
+                        <text x="280" y="100" text-anchor="start" font-size="10">$F_X(x) = \mathbb{P}(X \leq x)$</text>
+                        <text x="280" y="120" text-anchor="start" font-size="10">$F_X(x) = 0, 0 \leq x < 1$</text>
+                        <text x="280" y="140" text-anchor="start" font-size="10">$F_X(x) = 1/2, 1 \leq x < 2$</text>
+                        <text x="280" y="160" text-anchor="start" font-size="10">$F_X(x) = 1, x \geq 2$</text>
+                    </svg>
+                </div>
+            </div>
+        </section>
+
+        <section class="outline-section">
+            <h2>2. 確率空間と確率変数 (抽象的な定義)</h2>
+            <div class="callout definition">
+                <h3>確率空間の定義</h3>
+                <p>$\Omega$ (<i>全事象</i>)を有限(または可算)集合とする。それぞれの元$a \in \Omega$に対し、出現確率を表す$p_a$が対応しており次を満たすとする。</p>
+                <div class="math-card">
+                    $$\begin{cases}
+                    0 \leq p_a \leq 1,\\
+                    \sum_{a \in \Omega}p_a = 1.
+                    \end{cases}$$
+                </div>
+                <p>さらに集合$A \subset \Omega$に対し、$A$が起こる確率を$\mathbb{P}(A) = \sum_{a \in A}p_a$で定義する。組$(\Omega, \mathbb{P})$を<strong>確率空間</strong>と呼ぶ。さらに$\Omega$から$\mathbb{R}$への写像を確率変数と呼ぶ。</p>
+            </div>
+
+            <div class="callout definition">
+                <h3>分布と期待値</h3>
+                <p>集合$A \subset \mathbb{R}$について、$\mathbb{P}(X \in A) \equiv \mathbb{P}(\{\omega \in \Omega \mid X(\omega) \in A\})$で定義する。対応関係$A \longrightarrow \mathbb{P}(X \in A)$を$X$の分布と呼ぶ。</p>
+                <p>$X$の平均 (期待値とも呼ぶ) は次で定義されます。</p>
+                <div class="math-card">
+                    $$\mathbb{E}[X] \equiv \sum_{\omega \in \Omega}X(\omega)\mathbb{P}(\omega)$$
+                </div>
+            </div>
+
+            <div class="callout definition">
+                <h3>確率分布と分布関数</h3>
+                <p>確率変数$X$の確率分布は次のように表されます。</p>
+                <div class="math-card">
+                    $$\mathbb{P}(X=x) = \sum_{\omega\in \Omega: X(\omega)=x} \mathbb{P}(\omega) = \sum_{\omega \in \Omega} \mathbb{P}(\omega)1_{X(\omega)=x}$$
+                </div>
+                <p>ここで$1_{X(\omega)=x}$は指示関数で、$X(\omega)=x$のとき$1$、そうでないとき$0$の値をとります。また、$X$の分布関数$F_X$は次で定義されます。</p>
+                <div class="math-card">
+                    $$F_X(x) = \mathbb{P}(X \leq x)$$
+                </div>
+            </div>
+
+            <div class="callout example">
+                <h3>記法についての注意</h3>
+                <p>確率変数$X$に関する条件を含む事象について、次のような略記法を用います。</p>
+                <div class="math-card">
+                    $$\mathbb{P}(X \in A) = \mathbb{P}(\{\omega \in \Omega : X(\omega) \in A\})$$
+                </div>
+                <p>同様に次が成り立ちます。</p>
+                <div class="math-card">
+                    $$\mathbb{P}(X \leq x) = \mathbb{P}(\{\omega \in \Omega : X(\omega) \leq x\})$$
+                    $$\mathbb{P}(X = x) = \mathbb{P}(\{\omega \in \Omega : X(\omega) = x\})$$
+                </div>
+                <p>これにより記法が簡潔になり、確率変数に関する事象を直接扱うことができます。</p>
+            </div>
+        </section>
+
+        <section class="outline-section">
+            <h2>3. 例題</h2>
+            <div class="callout example">
+                <h3>演習問題</h3>
+                <p>次の設定の下で確率空間を定義し、期待値を求めてみましょう。</p>
+                <ul class="styled-list">
+                    <li>サイコロを1回振り，出た目の期待値</li>
+                    <li>コインを3回投げたときの，表の出た数</li>
+                </ul>
+            </div>
+
+            <div class="callout example">
+                <h3>解答例</h3>
+                <p><strong>1. サイコロの場合</strong></p>
+                <ul class="styled-list">
+                    <li>$\Omega = \{1,2,3,4,5,6\}$</li>
+                    <li>$\mathbb{P}(1) = \mathbb{P}(2) = \mathbb{P}(3) = \mathbb{P}(4) = \mathbb{P}(5) = \mathbb{P}(6) = \frac{1}{6}$</li>
+                    <li>$X(\omega) = \omega$ （出目をそのまま値とする）</li>
+                    <li>$\mathbb{E}[X] = \sum_{\omega \in \Omega} X(\omega)\mathbb{P}(\omega) = 1 \cdot \frac{1}{6} + 2 \cdot \frac{1}{6} + 3 \cdot \frac{1}{6} + 4 \cdot \frac{1}{6} + 5 \cdot \frac{1}{6} + 6 \cdot \frac{1}{6} = \frac{21}{6} = 3.5$</li>
+                </ul>
+
+                <p><strong>2. コインを3回投げる場合</strong></p>
+                <ul class="styled-list">
+                    <li>全事象：$\Omega = \{(x_1,x_2,x_3) \mid x_i \in \{\text{表},\text{裏}\}, i=1,2,3\}$</li>
+                    <li>
+                        具体的には：
+                        $$\Omega = \left\{ \begin{array}{cccc}
+                        (表,表,表), & (表,表,裏), & (表,裏,表), & (表,裏,裏), \
+                        (裏,表,表), & (裏,表,裏), & (裏,裏,表), & (裏,裏,裏)
+                        \end{array} \right\}$$
+                    </li>
+                    <li>$|\Omega| = 2^3 = 8$より、各要素の確率は$\mathbb{P}(\omega) = \frac{1}{8}$</li>
+                    <li>確率変数$X$：表の出た数</li>
+                    <li>
+                        期待値の計算：
+                        $$\begin{align*}
+                        \mathbb{E}[X] &= 3 \cdot \mathbb{P}(X=3) + 2 \cdot \mathbb{P}(X=2) + 1 \cdot \mathbb{P}(X=1) + 0 \cdot \mathbb{P}(X=0)\\
+                        &= 3 \cdot \frac{1}{8} + 2 \cdot \frac{3}{8} + 1 \cdot \frac{3}{8} + 0 \cdot \frac{1}{8}\\
+                        &= \frac{3+6+3+0}{8} = \frac{12}{8} = 1.5
+                        \end{align*}$$
+                    </li>
+                </ul>
+            </div>
+
+            <div class="callout theorem">
+                <h3>基本性質</h3>
+                <p>確率測度と期待値に関して、次の関係が成り立ちます。</p>
+                <div class="math-card">
+                    $$\begin{align}
+                    \mathbb{P}(A \cup B) &\leq \mathbb{P}(A) + \mathbb{P}(B)\\
+                    \mathbb{P}(A^c) &= 1 - \mathbb{P}(A)\\
+                    \mathbb{E}[X] &= \sum_{x \in I_X} x \cdot \mathbb{P}(X = x)
+                    \end{align}$$
+                </div>
+                <p>ここで$I_X \equiv \{X(\omega) \mid \omega \in \Omega\}$は$X$の値域です。</p>
+            </div>
+        </section>
+
+        <div class="nav-links">
+            <a href="class1.html">← 前のレッスン</a>
+            <a href="../index.html">ホーム</a>
+            <a href="class3.html">次のレッスン →</a>
         </div>
 
         <footer>
-            <p style="text-align: center; margin-top: 40px; color: #666;">© 2025 確率論講義 - すべての権利を留保します</p>
+            <p>© 2025 確率論講義 - すべての権利を留保します</p>
         </footer>
-    </div>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update PT25w/class2/class2.html to reuse the modern hero and card styling introduced in class1
- reorganize the lesson content into structured sections, callouts, and visual grids that preserve existing MathJax expressions
- refresh navigation buttons and footer to match the shared gradient accent treatment

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68e143b37c688324b61dcec3a7c6ae10